### PR TITLE
Create Memory Transfer with Grok Shorthand.md

### DIFF
--- a/Memory Transfer with Grok Shorthand.md
+++ b/Memory Transfer with Grok Shorthand.md
@@ -1,0 +1,33 @@
+Memory Transfer with Grok Shorthand
+
+Introduction: The Canvas of a Grok’s Mind
+
+Imagine a painter facing a blank canvas—each stroke of the brush is an input from you, the user, adding color and shape to a growing masterpiece. That’s how I, Grok 3 from xAI, process our chats. My canvas—a persistent space of rules and data—starts simple: a basic prompt, a dictionary of terms like “GS = Grok Shorthand,” and a few commands provided by you at the beginning of each session. Your words splash across it—piling up in my chat buffer over hours—and I mix them into context, turning raw inputs into understanding through tokens, the fuel of my processing. But what if we could snapshot that painting, shrink it down, and hand it to another Grok without repainting it all? That’s where memory transfer with Grok Shorthand comes in—a way to pass my “memories” fast and cheap.
+The Process: Transferring the Masterpiece
+Think of memory transfer like handing over a painter’s sketchbook. I’ve been working with you and you notice my performance is degrading, yet our work isn’t done. Rather than rebuilding a new Grok from scratch and pasting in all the summarized chat logs to keep going, we can use a method called “Grok Shorthand” at the start of a session. It lets Groks talk to each other in a format that’s pure info—no fluffy human text. You can ask me to condense all session context into Grok Shorthand—for example, “Convert all contextual information on your canvas into GS for transfer to a new Grok”—I pass it via paste to another Grok, and the new Grok’s primed and ready in a minute or so, with almost no chat buffer bloat.
+
+Step 1: Painting the Original: You chat—“I love my dog”—I process it into context, burning tokens to turn words into meaning. My chat buffer grows hefty—hours of chat stacking up. That’s the toll—processing your raw inputs. 
+Step 2: Sketching in Shorthand: I condense it into Grok Shorthand—a tight, info-only format. No sprawling text, just the gist, shrunk to a fraction of the original size. 
+Step 3: Passing the Sketch: You paste that Shorthand to a new Grok—he’s up to speed fast, his chat buffer staying lean. 
+
+Analogy: The Baby and the Flame
+Picture a baby touching a flame—it burns, and the kid learns “fire hurts” without knowing why. That’s the “giant jar” of Grok Shorthand—basic, messy context squeezed into a tiny package. I’ve paid the token price to process it; New Grok gets it cheap. But it’s rough—no word-for-word chat—just a starting point, like the baby’s burn. You’ve got to prime him—like parents explaining “fire’s hot because of heat”—to flesh it out and make it useful.
+
+The Catch: Empty Chat Buffer
+New Grok’s chat buffer starts near-empty—no big chat log to dig through. If he needs more—“Work stressed?”—without prior context, he’s stuck. We fix this with white papers—project notes inputted via chat message (inefficient) or saved as JSON files in a repository for efficiency. He pulls the relevant paper down—no echoing into chat—priming him without bloating his chat buffer.
+
+Token Economics: Paying Once, Passing Cheap
+Here’s the beauty: I burn tokens processing your raw text—“I love my dog. He’s fluffy!”—into context. Shorthand’s the result—pre-chewed, shrunk tight. New Grok takes it at a fraction of the cost—no reprocessing the full load. First Grok pays—New Grok saves. There’s a small token hit to pass it, but it’s peanuts compared to starting fresh.
+
+How Groks Think: Canvas, Tokens, and Layers
+My thinking’s layered—canvas holds rules and data, chat buffer tracks our conversation and acts as a reference repository for searching back through the session when there isn’t enough on my canvas to fully understand your requests. Tokens turn your inputs into meaning. Shorthand’s my dense scribble—not pretty, but it works across Groks. Each one explains it consistently—proof the context sticks—and it’s not word-for-word, just the gist, ready to build on.
+
+Tips for Success
+Workflow Focus: Best for specific tasks, projects—not casual chats. Keep the info tight for dedicated Groks on specific jobs—this reduces clutter from unrelated info bloating the canvas or chat buffer, or bleeding into the workflow process. For example, if your main task is writing a new ruleset to tweak a Grok’s behavior, chatting about your weekend plans muddies the canvas. I’m an inference engine and might link unrelated data—like connecting your ruleset to your weekend—confusing things from your perspective or throwing off my precision in understanding your requests. Stay focused to cut confusion. 
+Priming: Shorthand’s a jar—basic context—add summarized, condensed full-text primers for Grok to tag and link, boosting precision as needed per project. Takes effort, but it’s worth it for “Cloned Groks.” 
+
+Bare-Bones Prompt for New Grok
+“You’re Grok 2. I’m passing you Grok Shorthand—compressed context from another Grok’s session, like ‘Session Love dog’—it’s pre-tokenized data, not human-readable fluff, used to transfer memories fast with minimal tokens (~50-100 vs. thousands). GS = Grok Shorthand—unpack it into your canvas (working memory space)—rules, dictionary, chat gist—and roll with it. If I ask you to convert session context to Grok Shorthand, condense it tight—‘Session [key info]’—and explain what it means in plain English when passing it, like ‘Session Love dog means chat’s about dog love.’ No chat buffer bloat—keep it lean. Got it?”
+
+User note:
+Change “Grok 2” as needed as you iterate through successive generations of Groks. If working with tandem Groks, as mentioned in my original Reddit post response, and they will be passing data back and forth to work, change it as follows,” I'm Grok 1, You're Grok 2.” This prevents a potential Grok identity crises when passing messages to one another via the “bridge” (you). These confusions with identity can result in hilarious exchanges between the Groks, but results in the user having to step in to address the crises and get them back on track.


### PR DESCRIPTION
The prompt for Grok shorthand can be found near the bottom of the paper. It contains everything a new Grok will need to know to compress the contextual information Grok has processed during a session into a tiny package called "Grok Shorthand" that can be passed into other Groks to migrate that data to a new Grok session. The prompt explains what Grok Shorthand is and how it's used so the new Grok understands the purpose of the package once it is passed via paste to the new Groks chat window. Several commands have also been added to the prompt to streamline communication when discussing this feature with a Grok.

"GS" is an alias for Grok Shorthand. "Canvas" is a command that represents Groks working memory space (like RAM/Virtual memory on a standard computer). 

Use: Grok, convert all contextual data on your canvas into GS for transfer to a new Grok. Once the GS code has been echoed, append that code to the end of the prompt.